### PR TITLE
add --npm flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ This will add the following files:
 
 * `app.js`
 * `package.json`
-
-
 * `.gitignore`
 * `.csscomb.json`
 * `.eslintrc`
@@ -80,6 +78,16 @@ yo clay:component <name> --viewports 0-300,300-600,600+,1200+
 600+.css
 1200+.css
 ```
+
+### --npm
+
+This is useful if you want to quickly scaffold components for release on npm. Their name gets prepended with `clay-`, and they additionally get a `package.json`, `README.md`, and `.eslintrc`. All options and prompts for internal components are available for npm components.
+
+```
+yo clay:component <name> --npm
+```
+
+Note: It will create a `clay-<name>` folder in the current directory, rather than a `components/<name>` folder.
 
 ## Site Generator
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This is useful if you want to quickly scaffold components for release on npm. Th
 yo clay:component <name> --npm
 ```
 
-Note: It will create a `clay-<name>` folder in the current directory, rather than a `components/<name>` folder.
+Note: It will create all files in the current directory, rather than in a `components/<name>` folder.
 
 ## Site Generator
 

--- a/generators/component/index.js
+++ b/generators/component/index.js
@@ -35,9 +35,7 @@ module.exports = generators.NamedBase.extend({
     checkComponent: function () {
       var name = this.name,
         isNPM = this.isNPM,
-        hasComponentFolder = isNPM ?
-          fs.existsSync(this.destinationPath('clay-' + name)) : // check in current directory
-          fs.existsSync(this.destinationPath('components', name)), // check in components folder
+        hasComponentFolder = fs.existsSync(this.destinationPath('components', name)),
         // note: this.fs.exists() doesn't work for directories, hence fs.existsSync()
         hasNpmComponent;
 
@@ -50,14 +48,10 @@ module.exports = generators.NamedBase.extend({
         hasNpmComponent = false;
       }
 
-      if (hasComponentFolder) {
-        if (isNPM) {
-          this.log(chalk.red('Component already exists at clay-' + name));
-        } else {
-          this.log(chalk.red('Component already exists at components/' + name));
-        }
+      if (!isNPM && hasComponentFolder) {
+        this.log(chalk.red('Component already exists at components/' + name));
         process.exit(1);
-      } else if (hasNpmComponent) {
+      } else if (!isNPM && hasNpmComponent) {
         this.log(chalk.red('Component with a similar name was installed via npm: clay-' + name));
         process.exit(1);
       }
@@ -158,7 +152,7 @@ module.exports = generators.NamedBase.extend({
 
     // figure out what folder we should write to
     this.folder = isNPM ?
-      this.destinationPath('clay-' + name) :
+      this.destinationPath() :
       this.destinationPath('components', name);
 
     // folderName is used for the folder if it's an npm component,

--- a/generators/component/index.js
+++ b/generators/component/index.js
@@ -257,8 +257,7 @@ module.exports = generators.NamedBase.extend({
     updatePackage: function () {
       var isNPM = this.isNPM,
         folder = this.folder,
-        name = this.name,
-        folderName = isNPM ? 'clay-' + name : name,
+        folderName = this.folderName,
         ext = this.tplExtension,
         filePath = path.join(folder, 'package.json'),
         defaults = {
@@ -274,6 +273,19 @@ module.exports = generators.NamedBase.extend({
         _.defaults(pkg, defaults);
 
         this.fs.writeJSON(filePath, pkg);
+      }
+    },
+
+    addReadme: function () {
+      var isNPM = this.isNPM,
+        folder = this.folder,
+        folderName = this.folderName,
+        name = this.name,
+        readmePath = path.join(folder, 'README.md'),
+        hasReadme = this.fs.exists(readmePath);
+
+      if (isNPM && !hasReadme) {
+        this.fs.copyTpl(this.templatePath('README.md'), readmePath, { folderName: folderName, name: name });
       }
     }
   }

--- a/generators/component/index.js
+++ b/generators/component/index.js
@@ -261,16 +261,17 @@ module.exports = generators.NamedBase.extend({
         folderName = isNPM ? 'clay-' + name : name,
         ext = this.tplExtension,
         filePath = path.join(folder, 'package.json'),
-        pkg;
-
-      if (this.isNPM) {
-        pkg = this.fs.readJSON(filePath);
-
-        _.defaults(pkg, {
+        defaults = {
           name: folderName,
           template: 'template.' + ext,
           style: '*.css'
-        });
+        },
+        pkg;
+
+      if (isNPM) {
+        pkg = this.fs.readJSON(filePath, defaults);
+
+        _.defaults(pkg, defaults);
 
         this.fs.writeJSON(filePath, pkg);
       }

--- a/generators/component/index.js
+++ b/generators/component/index.js
@@ -287,6 +287,17 @@ module.exports = generators.NamedBase.extend({
       if (isNPM && !hasReadme) {
         this.fs.copyTpl(this.templatePath('README.md'), readmePath, { folderName: folderName, name: name });
       }
+    },
+
+    addEslint: function () {
+      var isNPM = this.isNPM,
+        folder = this.folder,
+        eslintPath = path.join(folder, '.eslintrc'),
+        hasEslint = this.fs.exists(eslintPath);
+
+      if (isNPM && !hasEslint) {
+        this.fs.copy(this.templatePath('.eslintrc'), eslintPath);
+      }
     }
   }
 });

--- a/generators/component/templates/.eslintrc
+++ b/generators/component/templates/.eslintrc
@@ -1,0 +1,79 @@
+{
+  "env": {
+    "browser": true,
+    "node": true,
+    "mocha": true
+  },
+  // add global vars for chai, etc
+  "globals": {
+    "expect": false,
+    "chai": false,
+    "sinon": false,
+    "DS": false
+  },
+  // enable the es6 features supported by our browsers / iojs
+  "ecmaFeatures": {
+    "blockBindings": true,
+    "forOf": true,
+    "objectLiteralDuplicateProperties": true,
+    "objectLiteralShorthandProperties": true,
+    "objectLiteralShorthandMethods": true,
+    "octalLiterals": true,
+    "binaryLiterals": true,
+    "templateStrings": true,
+    "generators": true
+  },
+  "rules": {
+    // possible errors
+    "no-extra-parens": 1,
+    "valid-jsdoc": [1, {
+      "requireReturn": false,
+      "requireParamDescription": false,
+      "requireReturnDescription": false
+    }],
+    // best practices
+    "complexity": [2, 8],
+    "default-case": 2,
+    "guard-for-in": 2,
+    "no-alert": 1,
+    "no-floating-decimal": 1,
+    "no-self-compare": 2,
+    "no-throw-literal": 2,
+    "no-void": 2,
+    "vars-on-top": 2,
+    "wrap-iife": 2,
+    // strict mode
+    "strict": [2, "global"],
+    // variables
+    "no-unused-vars": 2,
+    // node.js
+    "handle-callback-err": [2, "^.*(e|E)rr"],
+    "no-mixed-requires": 0,
+    "no-new-require": 2,
+    "no-path-concat": 2,
+    // stylistic issues
+    "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+    "comma-style": [2, "last"],
+    "indent": [2, 2, { "SwitchCase": 1 }],
+    "max-nested-callbacks": [2, 4],
+    "newline-after-var": [2, "always"],
+    "no-nested-ternary": 2,
+    "no-spaced-func": 0,
+    "no-trailing-spaces": 2,
+    "no-underscore-dangle": 0,
+    "no-unneeded-ternary": 1,
+    "one-var": 2,
+    "quotes": [2, "single", "avoid-escape"],
+    "semi": [2, "always"],
+    "space-after-keywords": [2, "always"],
+    "space-before-blocks": [2, "always"],
+    "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
+    "space-infix-ops": [1, {"int32Hint": false}],
+    "spaced-comment": [2, "always"],
+    // es6
+    "generator-star-spacing": [2, "before"],
+    // legacy jshint rules
+    "max-depth": [2, 4],
+    "max-params": [2, 4]
+  }
+}

--- a/generators/component/templates/README.md
+++ b/generators/component/templates/README.md
@@ -1,0 +1,17 @@
+# <%= folderName %>
+
+A component for [Clay](https://github.com/nymag/amphora/wiki#clay-is-divided-into-components).
+
+## Install
+
+```
+npm install --save <%= folderName %>
+```
+
+Adds a <%= name %> component.
+
+## Usage
+
+Once you install it, it will be automatically recognized by `amphora`.
+
+To include it, create an instance of it and add a reference to a component list.

--- a/generators/component/templates/all.css
+++ b/generators/component/templates/all.css
@@ -1,3 +1,3 @@
-.<%= name %> {
+.<%= folderName %> {
   /* add your styles here! */
 }

--- a/generators/component/templates/bootstrap.yml
+++ b/generators/component/templates/bootstrap.yml
@@ -1,3 +1,3 @@
 components:
-  <%= name %>:<% for (var i = 0; i < fields.length; i++) { %>
+  <%= folderName %>:<% for (var i = 0; i < fields.length; i++) { %>
     <%= fields[i] %>: ''<% } %>

--- a/generators/component/templates/print.css
+++ b/generators/component/templates/print.css
@@ -1,4 +1,4 @@
-.<%= name %> {
+.<%= folderName %> {
   /*
     components are hidden by default when printing
     to add print styles, remove the rule below

--- a/generators/component/templates/template.jade
+++ b/generators/component/templates/template.jade
@@ -1,3 +1,3 @@
 - dataUri = _ref || _self
-<%= tag %>.<%= name %>(data-uri=dataUri)
+<%= tag %>.<%= folderName %>(data-uri=dataUri)
   // add your component internals here

--- a/generators/component/templates/template.nunjucks
+++ b/generators/component/templates/template.nunjucks
@@ -1,4 +1,4 @@
-<<%= tag %> data-uri="{{ _ref or _self }}" class="<%= name %>">
+<<%= tag %> data-uri="{{ _ref or _self }}" class="<%= folderName %>">
 
   {# add your component internals here #}
 

--- a/generators/component/test.js
+++ b/generators/component/test.js
@@ -182,6 +182,13 @@ describe('clay:component', function () {
       assert.fileContent(file, /"name": "((.+?)\/)?clay-(.+?)"/);
     });
 
+    it('adds style to package.json', function () {
+      var file = path.join(npmFolder, 'package.json');
+
+      assert.file(file);
+      assert.fileContent(file, /"style": "\*\.css"/);
+    });
+
     // it('creates readme if it doesn\'t exist', function () {
     //   var file = path.join(npmFolder, 'package.json');
     //

--- a/generators/component/test.js
+++ b/generators/component/test.js
@@ -151,21 +151,63 @@ describe('clay:component', function () {
       var file = path.join(npmFolder, 'all.css');
 
       assert.file(file);
-      assert.fileContent(file, /^\.foo \{/);
+      assert.fileContent(file, /^\.clay-foo \{/);
     });
 
     it('adds a print.css stylesheet', function () {
       var file = path.join(npmFolder, 'print.css');
 
       assert.file(file);
-      assert.fileContent(file, /^\.foo \{/);
+      assert.fileContent(file, /^\.clay-foo \{/);
     });
 
     it('adds a template', function () {
       var file = path.join(npmFolder, 'template.nunjucks');
 
       assert.file(file);
-      assert.fileContent(file, /class="foo"/);
+      assert.fileContent(file, /class="clay-foo"/);
     });
+
+    // it('adds template to package.json', function () {
+    //   var file = path.join(npmFolder, 'package.json');
+    //
+    //   assert.file(file);
+    //   assert.fileContent(file, /"template": "template.nunjucks"/);
+    // });
+    //
+    // it('adds name to package.json', function () {
+    //   var file = path.join(npmFolder, 'package.json');
+    //
+    //   assert.file(file);
+    //   assert.fileContent(file, /"name": "((.+?)\/)?clay-(.+?)"/);
+    // });
+
+    // it('creates readme if it doesn\'t exist', function () {
+    //   var file = path.join(npmFolder, 'package.json');
+    //
+    //   assert.file(file);
+    //   assert.fileContent(file, /"template": "template.nunjucks"/);
+    // });
+    //
+    // it('creates eslintrc', function () {
+    //   var file = path.join(npmFolder, 'package.json');
+    //
+    //   assert.file(file);
+    //   assert.fileContent(file, /"template": "template.nunjucks"/);
+    // });
+    //
+    // it('creates .gitignore if it doesn\'t exist', function () {
+    //   var file = path.join(npmFolder, 'package.json');
+    //
+    //   assert.file(file);
+    //   assert.fileContent(file, /"template": "template.nunjucks"/);
+    // });
+    //
+    // it('creates license if it doesn\'t exist', function () {
+    //   var file = path.join(npmFolder, 'package.json');
+    //
+    //   assert.file(file);
+    //   assert.fileContent(file, /"template": "template.nunjucks"/);
+    // });
   });
 });

--- a/generators/component/test.js
+++ b/generators/component/test.js
@@ -168,19 +168,19 @@ describe('clay:component', function () {
       assert.fileContent(file, /class="clay-foo"/);
     });
 
-    // it('adds template to package.json', function () {
-    //   var file = path.join(npmFolder, 'package.json');
-    //
-    //   assert.file(file);
-    //   assert.fileContent(file, /"template": "template.nunjucks"/);
-    // });
-    //
-    // it('adds name to package.json', function () {
-    //   var file = path.join(npmFolder, 'package.json');
-    //
-    //   assert.file(file);
-    //   assert.fileContent(file, /"name": "((.+?)\/)?clay-(.+?)"/);
-    // });
+    it('adds template to package.json', function () {
+      var file = path.join(npmFolder, 'package.json');
+
+      assert.file(file);
+      assert.fileContent(file, /"template": "template.nunjucks"/);
+    });
+
+    it('adds name to package.json', function () {
+      var file = path.join(npmFolder, 'package.json');
+
+      assert.file(file);
+      assert.fileContent(file, /"name": "((.+?)\/)?clay-(.+?)"/);
+    });
 
     // it('creates readme if it doesn\'t exist', function () {
     //   var file = path.join(npmFolder, 'package.json');

--- a/generators/component/test.js
+++ b/generators/component/test.js
@@ -194,26 +194,9 @@ describe('clay:component', function () {
 
       assert.file(file);
     });
-    //
-    // it('creates eslintrc', function () {
-    //   var file = path.join(npmFolder, 'package.json');
-    //
-    //   assert.file(file);
-    //   assert.fileContent(file, /"template": "template.nunjucks"/);
-    // });
-    //
-    // it('creates .gitignore if it doesn\'t exist', function () {
-    //   var file = path.join(npmFolder, 'package.json');
-    //
-    //   assert.file(file);
-    //   assert.fileContent(file, /"template": "template.nunjucks"/);
-    // });
-    //
-    // it('creates license if it doesn\'t exist', function () {
-    //   var file = path.join(npmFolder, 'package.json');
-    //
-    //   assert.file(file);
-    //   assert.fileContent(file, /"template": "template.nunjucks"/);
-    // });
+
+    it('creates eslintrc', function () {
+      assert.file(path.join(npmFolder, '.eslintrc'));
+    });
   });
 });

--- a/generators/component/test.js
+++ b/generators/component/test.js
@@ -137,66 +137,58 @@ describe('clay:component', function () {
   });
 
   describe('--npm', function () {
-    var npmFolder = 'clay-foo';
-
     before(function (done) {
       runGenerator({ npm: true }, done);
     });
 
-    it('generates component in current folder', function () {
-      assert.file(npmFolder);
-    });
-
     it('adds an all.css stylesheet', function () {
-      var file = path.join(npmFolder, 'all.css');
+      var file = 'all.css';
 
       assert.file(file);
       assert.fileContent(file, /^\.clay-foo \{/);
     });
 
     it('adds a print.css stylesheet', function () {
-      var file = path.join(npmFolder, 'print.css');
+      var file = 'print.css';
 
       assert.file(file);
       assert.fileContent(file, /^\.clay-foo \{/);
     });
 
     it('adds a template', function () {
-      var file = path.join(npmFolder, 'template.nunjucks');
+      var file = 'template.nunjucks';
 
       assert.file(file);
       assert.fileContent(file, /class="clay-foo"/);
     });
 
     it('adds template to package.json', function () {
-      var file = path.join(npmFolder, 'package.json');
+      var file = 'package.json';
 
       assert.file(file);
       assert.fileContent(file, /"template": "template.nunjucks"/);
     });
 
     it('adds name to package.json', function () {
-      var file = path.join(npmFolder, 'package.json');
+      var file = 'package.json';
 
       assert.file(file);
       assert.fileContent(file, /"name": "((.+?)\/)?clay-(.+?)"/);
     });
 
     it('adds style to package.json', function () {
-      var file = path.join(npmFolder, 'package.json');
+      var file = 'package.json';
 
       assert.file(file);
       assert.fileContent(file, /"style": "\*\.css"/);
     });
 
     it('creates readme if it doesn\'t exist', function () {
-      var file = path.join(npmFolder, 'README.md');
-
-      assert.file(file);
+      assert.file('README.md');
     });
 
     it('creates eslintrc', function () {
-      assert.file(path.join(npmFolder, '.eslintrc'));
+      assert.file('.eslintrc');
     });
   });
 });

--- a/generators/component/test.js
+++ b/generators/component/test.js
@@ -189,12 +189,11 @@ describe('clay:component', function () {
       assert.fileContent(file, /"style": "\*\.css"/);
     });
 
-    // it('creates readme if it doesn\'t exist', function () {
-    //   var file = path.join(npmFolder, 'package.json');
-    //
-    //   assert.file(file);
-    //   assert.fileContent(file, /"template": "template.nunjucks"/);
-    // });
+    it('creates readme if it doesn\'t exist', function () {
+      var file = path.join(npmFolder, 'README.md');
+
+      assert.file(file);
+    });
     //
     // it('creates eslintrc', function () {
     //   var file = path.join(npmFolder, 'package.json');

--- a/generators/component/test.js
+++ b/generators/component/test.js
@@ -135,4 +135,37 @@ describe('clay:component', function () {
       assert.file(path.join(folder, 'bootstrap.yml'));
     });
   });
+
+  describe('--npm', function () {
+    var npmFolder = 'clay-foo';
+
+    before(function (done) {
+      runGenerator({ npm: true }, done);
+    });
+
+    it('generates component in current folder', function () {
+      assert.file(npmFolder);
+    });
+
+    it('adds an all.css stylesheet', function () {
+      var file = path.join(npmFolder, 'all.css');
+
+      assert.file(file);
+      assert.fileContent(file, /^\.foo \{/);
+    });
+
+    it('adds a print.css stylesheet', function () {
+      var file = path.join(npmFolder, 'print.css');
+
+      assert.file(file);
+      assert.fileContent(file, /^\.foo \{/);
+    });
+
+    it('adds a template', function () {
+      var file = path.join(npmFolder, 'template.nunjucks');
+
+      assert.file(file);
+      assert.fileContent(file, /class="foo"/);
+    });
+  });
 });


### PR DESCRIPTION
* flag for `clay:component` generator
* if set, will create `clay-<name>` component in current folder
* allows all other options for the component generator (tags, viewports, etc)
* will also update/add `package.json`
* will also add readme and eslint if they don't exist